### PR TITLE
Fix React rendering for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,19 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Clock, ChevronLeft, ChevronRight, CheckCircle, XCircle, AlertCircle, Trophy, RefreshCw, BookOpen, Target } from 'lucide-react';
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reqzilla Practice</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/lucide-react@latest/dist/umd/lucide-react.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="bg-gray-50">
+  <div id="root"></div>
+  <script type="text/babel">
+    const { Clock, ChevronLeft, ChevronRight, CheckCircle, XCircle, AlertCircle, Trophy, RefreshCw, BookOpen, Target } = lucideReact;
 
 // Complete Mock Exam 1 - 45 questions following IREB format
 const mockExam1 = {
@@ -1430,7 +1444,7 @@ const mockExam2 = {
 };
 
 // Main component
-export default function IREBPracticeInterface() {
+function IREBPracticeInterface() {
   const [selectedExam, setSelectedExam] = useState(null);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [selectedAnswers, setSelectedAnswers] = useState([]);
@@ -2415,3 +2429,8 @@ export default function IREBPracticeInterface() {
     </div>
   );
 }
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<IREBPracticeInterface />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a real HTML document that loads React from CDNs
- embed the exam app as an inline Babel script

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f77c7b908832f8315a067a81d400b